### PR TITLE
Feature - Save Log as Template

### DIFF
--- a/src/app/user/createlog/page.tsx
+++ b/src/app/user/createlog/page.tsx
@@ -298,6 +298,7 @@ export default function CreateLog() {
         onClose={() => setIsModalOpen(false)}
         onConfirm={() => handleSaveLog()}
         onSecondaryAction={handleSaveAsTemplate}
+        data={selectedExercises}
       />
       <TemplatesModal
         open={isTemplateModalOpen}

--- a/src/app/user/createlog/page.tsx
+++ b/src/app/user/createlog/page.tsx
@@ -180,11 +180,7 @@ export default function CreateLog() {
         console.error("Error saving log: ", error.message);
       }
     }
-    setIsModalOpen(false);
-  };
-
-  const handleSaveAsTemplate = async () => {
-    handleSaveLog(true);
+    setIsModalOpen(true);
   };
 
   return (
@@ -288,16 +284,14 @@ export default function CreateLog() {
       {/* Save Button */}
       <div className="flex flex-col gap-y-9">
         <BasicRoundedButton
-          onClick={() => setIsModalOpen(true)}
-          label="Save Your Log"
+          onClick={() => handleSaveLog()}
+          label="Save Log"
           disabled={selectedExercises.length === 0}
         ></BasicRoundedButton>
       </div>
       <SaveLogModal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        onConfirm={() => handleSaveLog()}
-        onSecondaryAction={handleSaveAsTemplate}
         data={selectedExercises}
       />
       <TemplatesModal

--- a/src/components/modals/SaveAsTemplateModal.tsx
+++ b/src/components/modals/SaveAsTemplateModal.tsx
@@ -1,5 +1,6 @@
 import { LoggingClient } from "@/app/clients/logging-client/logging-client";
 import { useAuthSession } from "@/lib/contexts/auth-context/auth-context";
+import { ExerciseActivity } from "@/models/exercise-activity.model";
 import { Modal } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { FiX } from "react-icons/fi";
@@ -9,7 +10,7 @@ import SuccessModal from "./SuccessModal";
 interface SaveAsTemplateModalProps {
   open: boolean;
   onClose: () => void;
-  data: any;
+  data: ExerciseActivity[];
 }
 
 const SaveAsTemplateModal: React.FC<SaveAsTemplateModalProps> = ({

--- a/src/components/modals/SaveAsTemplateModal.tsx
+++ b/src/components/modals/SaveAsTemplateModal.tsx
@@ -83,6 +83,7 @@ const SaveAsTemplateModal: React.FC<SaveAsTemplateModalProps> = ({
           </button>
 
           <div className="px-4 items-center">
+            <h1> Give Your Template a Name</h1>
             <input
               type="text"
               id="templateName"

--- a/src/components/modals/SaveAsTemplateModal.tsx
+++ b/src/components/modals/SaveAsTemplateModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { FiX } from "react-icons/fi";
 import { BasicRoundedButton } from "../buttons/basic-rounded-button/Basic-rounded-button";
+import SuccessModal from "./SuccessModal";
 
 interface SaveAsTemplateModalProps {
   open: boolean;
@@ -21,6 +22,7 @@ const SaveAsTemplateModal: React.FC<SaveAsTemplateModalProps> = ({
   const [unit, setUnit] = useState<string>("lbs");
   const [templateName, setTemplateName] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
     const savedUnit = localStorage.getItem("weightUnit");
@@ -65,68 +67,72 @@ const SaveAsTemplateModal: React.FC<SaveAsTemplateModalProps> = ({
         console.error("Error saving log: ", error.message);
       }
     }
+    setIsModalOpen(true);
   };
 
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      className="flex justify-center items-center"
-    >
-      <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
-        <button className="absolute top-2 right-2" onClick={onClose}>
-          <FiX />
-        </button>
+    <div>
+      <Modal
+        open={open}
+        onClose={onClose}
+        className="flex justify-center items-center"
+      >
+        <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
+          <button className="absolute top-2 right-2" onClick={onClose}>
+            <FiX />
+          </button>
 
-        <div className="px-4 items-center">
-          <input
-            type="text"
-            id="templateName"
-            value={templateName}
-            onChange={(e) => setTemplateName(e.target.value)}
-            placeholder="Template Name"
-            className="border rounded-xl p-2 bg-gray-50 w-full text-center"
-          />
-          {errorMessage && (
-            <p className="text-red-500 text-center mt-2">{errorMessage}</p>
-          )}
-        </div>
-
-        <div>
-          <h1>Please Review Your Template</h1>
-          <div>
-            {data.map((exercise, index) => (
-              <div
-                className="flex justify-between items-center mb-1"
-                key={index}
-              >
-                <div className="text-gray-700">{exercise.exerciseName}</div>
-                <div className="text-gray-500">
-                  Sets: {exercise.sets.length}
-                </div>
-              </div>
-            ))}
+          <div className="px-4 items-center">
+            <input
+              type="text"
+              id="templateName"
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              placeholder="Template Name"
+              className="border rounded-xl p-2 bg-gray-50 w-full text-center"
+            />
+            {errorMessage && (
+              <p className="text-red-500 text-center mt-2">{errorMessage}</p>
+            )}
           </div>
-          <p>
-            * Please note that only the exercise name and number of sets will be
-            saved when adding the log as a template.
-          </p>
-        </div>
 
-        <div className="flex flex-col">
-          <h3>
-            You've successfully logged your exercises for today. Keep up the
-            fantastic work!
-          </h3>
+          <div>
+            <h1>Please Review Your Template</h1>
+            <div>
+              {data.map((exercise, index) => (
+                <div
+                  className="flex justify-between items-center mb-1"
+                  key={index}
+                >
+                  <div className="text-gray-700">{exercise.exerciseName}</div>
+                  <div className="text-gray-500">
+                    Sets: {exercise.sets.length}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p>
+              * Please note that only the exercise name and number of sets will
+              be saved when adding the log as a template.
+            </p>
+          </div>
+
+          <div className="flex flex-col">
+            <h3>
+              You've successfully logged your exercises for today. Keep up the
+              fantastic work!
+            </h3>
+          </div>
+          <div className="flex flex-col justify-between h-28">
+            <BasicRoundedButton
+              onClick={() => handleSaveTemplate()}
+              label="Save Template"
+            ></BasicRoundedButton>
+          </div>
         </div>
-        <div className="flex flex-col justify-between h-28">
-          <BasicRoundedButton
-            onClick={() => handleSaveTemplate()}
-            label="Save Template"
-          ></BasicRoundedButton>
-        </div>
-      </div>
-    </Modal>
+      </Modal>
+      <SuccessModal open={isModalOpen} />
+    </div>
   );
 };
 

--- a/src/components/modals/SaveAsTemplateModal.tsx
+++ b/src/components/modals/SaveAsTemplateModal.tsx
@@ -1,0 +1,82 @@
+import { LoggingClient } from "@/app/clients/logging-client/logging-client";
+import { Modal } from "@mui/material";
+import React from "react";
+import { FiX } from "react-icons/fi";
+import { BasicRoundedButton } from "../buttons/basic-rounded-button/Basic-rounded-button";
+
+interface SaveAsTemplateModalProps {
+  open: boolean;
+  onClose: () => void;
+  data: any;
+}
+
+const SaveAsTemplateModal: React.FC<SaveAsTemplateModalProps> = ({
+  open,
+  onClose,
+  data,
+}) => {
+  const handleSaveLog = async (isTemplate: boolean = false) => {
+    if (session?.user?._id) {
+      const logData = [
+        {
+          exercises: data.map((exerciseActivity) => {
+            return {
+              exerciseName: exerciseActivity.exerciseName,
+              sets: exerciseActivity.sets.map((set, index) => {
+                return {
+                  setNumber: index + 1,
+                  weight: 0,
+                  unit: "lbs",
+                  reps: 0,
+                };
+              }),
+            };
+          }),
+          isTemplate: true,
+        },
+      ];
+
+      try {
+        await LoggingClient.saveLog({
+          logs: logData,
+        });
+      } catch (error: any) {
+        //TODO: we need some UI feedback to show the user that the log was not saved
+        console.error("Error saving log: ", error.message);
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      className="flex justify-center items-center"
+    >
+      <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
+        <button className="absolute top-2 right-2" onClick={onClose}>
+          <FiX />
+        </button>
+        <img
+          src="/images/create-log-page/modal-splash.jpg"
+          alt="modal-image"
+          style={{ height: "50%" }}
+        />
+        <div className="flex flex-col">
+          <h3>
+            You've successfully logged your exercises for today. Keep up the
+            fantastic work!
+          </h3>
+        </div>
+        <div className="flex flex-col justify-between h-28">
+          <BasicRoundedButton
+            onClick={() => handleSaveLog()}
+            label="Add Log as Template"
+          ></BasicRoundedButton>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default SaveAsTemplateModal;

--- a/src/components/modals/SaveLogModal.tsx
+++ b/src/components/modals/SaveLogModal.tsx
@@ -1,55 +1,66 @@
 import { Modal } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 import { FiX } from "react-icons/fi";
 import { BasicRoundedButton } from "../buttons/basic-rounded-button/Basic-rounded-button";
+import SaveAsTemplateModal from "./SaveAsTemplateModal";
 
 interface SaveLogModalProps {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
   onSecondaryAction: () => void;
+  data?: any;
 }
 
 const SaveLogModal: React.FC<SaveLogModalProps> = ({
   open,
   onClose,
   onConfirm,
-  onSecondaryAction,
+  data,
 }) => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      className="flex justify-center items-center"
-    >
-      <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
-        <button className="absolute top-2 right-2" onClick={onClose}>
-          <FiX />
-        </button>
-        <img
-          src="/images/create-log-page/modal-splash.jpg"
-          alt="modal-image"
-          style={{ height: "50%" }}
-        />
-        <div className="flex flex-col">
-          <h1 className="text-2xl"> GREAT JOB! </h1>
-          <h3>
-            You've successfully logged your exercises for today. Keep up the
-            fantastic work!
-          </h3>
+    <div>
+      <Modal
+        open={open}
+        onClose={onClose}
+        className="flex justify-center items-center"
+      >
+        <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
+          <button className="absolute top-2 right-2" onClick={onClose}>
+            <FiX />
+          </button>
+          <img
+            src="/images/create-log-page/modal-splash.jpg"
+            alt="modal-image"
+            style={{ height: "50%" }}
+          />
+          <div className="flex flex-col">
+            <h1 className="text-2xl"> GREAT JOB! </h1>
+            <h3>
+              You've successfully logged your exercises for today. Keep up the
+              fantastic work!
+            </h3>
+          </div>
+          <div className="flex flex-col justify-between h-28">
+            <BasicRoundedButton
+              onClick={onConfirm}
+              label="Return To Home"
+            ></BasicRoundedButton>
+            <BasicRoundedButton
+              onClick={() => setIsModalOpen(true)}
+              label="Save Log as Template"
+            ></BasicRoundedButton>
+          </div>
         </div>
-        <div className="flex flex-col justify-between h-28">
-          <BasicRoundedButton
-            onClick={onConfirm}
-            label="Done"
-          ></BasicRoundedButton>
-          <BasicRoundedButton
-            onClick={onSecondaryAction}
-            label="Add Log as Template"
-          ></BasicRoundedButton>
-        </div>
-      </div>
-    </Modal>
+      </Modal>
+      <SaveAsTemplateModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        data={data}
+      />
+    </div>
   );
 };
 

--- a/src/components/modals/SaveLogModal.tsx
+++ b/src/components/modals/SaveLogModal.tsx
@@ -7,17 +7,10 @@ import SaveAsTemplateModal from "./SaveAsTemplateModal";
 interface SaveLogModalProps {
   open: boolean;
   onClose: () => void;
-  onConfirm: () => void;
-  onSecondaryAction: () => void;
   data?: any;
 }
 
-const SaveLogModal: React.FC<SaveLogModalProps> = ({
-  open,
-  onClose,
-  onConfirm,
-  data,
-}) => {
+const SaveLogModal: React.FC<SaveLogModalProps> = ({ open, onClose, data }) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   return (
@@ -42,12 +35,9 @@ const SaveLogModal: React.FC<SaveLogModalProps> = ({
               You've successfully logged your exercises for today. Keep up the
               fantastic work!
             </h3>
+            <h3>Do you want to save the log as a template as well?</h3>
           </div>
           <div className="flex flex-col justify-between h-28">
-            <BasicRoundedButton
-              onClick={onConfirm}
-              label="Return To Home"
-            ></BasicRoundedButton>
             <BasicRoundedButton
               onClick={() => setIsModalOpen(true)}
               label="Save Log as Template"

--- a/src/components/modals/SuccessModal.tsx
+++ b/src/components/modals/SuccessModal.tsx
@@ -1,4 +1,5 @@
 import { Modal } from "@mui/material";
+import Link from "next/link";
 import React from "react";
 import { FiX } from "react-icons/fi";
 
@@ -7,17 +8,15 @@ interface SuccessModalProps {
   onClose: () => void;
 }
 
-const SuccessModal: React.FC<SuccessModalProps> = ({ open, onClose }) => {
+const SuccessModal: React.FC<SuccessModalProps> = ({ open }) => {
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      className="flex justify-center items-center"
-    >
+    <Modal open={open} className="flex justify-center items-center">
       <div className="flex flex-col w-1/2 h-3/4 bg-white p-10 rounded-xl relative justify-evenly items-center text-center">
-        <button className="absolute top-2 right-2" onClick={onClose}>
-          <FiX />
-        </button>
+        <Link href={"/user/mytemplates"}>
+          <button className="absolute top-2 right-2">
+            <FiX />
+          </button>
+        </Link>
         <img
           src="/images/create-log-page/modal-splash.jpg"
           alt="modal-image"
@@ -29,6 +28,8 @@ const SuccessModal: React.FC<SuccessModalProps> = ({ open, onClose }) => {
             Your exercise template has been saved successfully. You can now
             reuse this template to log your exercises next time!
           </h3>
+          <Link href={"/user/home"}> Return to Home </Link>
+          <Link href={"user/mytemplates"}> View Templates </Link>
         </div>
       </div>
     </Modal>

--- a/src/components/modals/SuccessModal.tsx
+++ b/src/components/modals/SuccessModal.tsx
@@ -5,7 +5,6 @@ import { FiX } from "react-icons/fi";
 
 interface SuccessModalProps {
   open: boolean;
-  onClose: () => void;
 }
 
 const SuccessModal: React.FC<SuccessModalProps> = ({ open }) => {
@@ -29,7 +28,7 @@ const SuccessModal: React.FC<SuccessModalProps> = ({ open }) => {
             reuse this template to log your exercises next time!
           </h3>
           <Link href={"/user/home"}> Return to Home </Link>
-          <Link href={"user/mytemplates"}> View Templates </Link>
+          <Link href={"/user/mytemplates"}> View Templates </Link>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
- When user clicks add log as template, a modal opens up where the user has to input a name for the template. They can then save the log as a template
- When the user clicks “save as a template”, they are directed to a confirmation page mentioning that the template was saved successfully
- When user gets the success message, they can click the X button to return to /mytemplates page, or they can click on two button links to choose between /mytemplates or /home