### PR TITLE
Updated sigin and signup textinputs to tweak capitilization on ios devices

### DIFF
--- a/src/components/input-fields/password-input-field/Password-input-field.tsx
+++ b/src/components/input-fields/password-input-field/Password-input-field.tsx
@@ -39,7 +39,11 @@ export const PasswordInputField = ({
       helperText={helperText}
       disabled={disabled}
       onBlur={onBlur}
-      inputProps={{ maxLength }}
+      inputProps={{
+        maxLength,
+        autoCapitalize: "off",
+        "aria-autocomplete": "none",
+      }}
       sx={{
         marginTop: "4px",
         marginBottom: "4px",

--- a/src/components/input-fields/text-input-field/Form-text-input-field.tsx
+++ b/src/components/input-fields/text-input-field/Form-text-input-field.tsx
@@ -1,4 +1,4 @@
-import { TextField } from "@mui/material";
+import { InputBaseComponentProps, TextField } from "@mui/material";
 
 // Reusable text field we can use in forms (for basic text and email inputs)
 interface FormTextInputFieldProps {
@@ -12,6 +12,7 @@ interface FormTextInputFieldProps {
   error?: boolean;
   disabled?: boolean;
   maxLength?: number;
+  inputProps?: InputBaseComponentProps;
 }
 
 export function FormTextInputField({
@@ -25,6 +26,7 @@ export function FormTextInputField({
   disabled,
   onBlur,
   maxLength,
+  inputProps,
 }: FormTextInputFieldProps) {
   return (
     <TextField
@@ -43,6 +45,7 @@ export function FormTextInputField({
         style: {
           fontFamily: "Roboto, sans-serif",
         },
+        ...inputProps,
       }}
       sx={{
         marginTop: "4px",

--- a/src/components/signin-form/Signin-form.tsx
+++ b/src/components/signin-form/Signin-form.tsx
@@ -128,6 +128,10 @@ export function SigninForm() {
                   email: value,
                 });
               }}
+              inputProps={{
+                autoCapitalize: "off",
+                "aria-autocomplete": "none",
+              }}
             />
             <PasswordInputField
               id="password"

--- a/src/components/signup-form/Signup-form.tsx
+++ b/src/components/signup-form/Signup-form.tsx
@@ -129,6 +129,10 @@ export default function SignupForm() {
                   username: value,
                 });
               }}
+              inputProps={{
+                autoCapitalize: "off",
+                "aria-autocomplete": "none",
+              }}
             />
             <FormTextInputField
               id="email"
@@ -148,6 +152,10 @@ export default function SignupForm() {
                   ...formFieldValues,
                   email: value,
                 });
+              }}
+              inputProps={{
+                autoCapitalize: "off",
+                "aria-autocomplete": "none",
               }}
             />
             <PasswordInputField


### PR DESCRIPTION
- For password inputs, I turned off autocapitalize and autocomplete
- For regular form inputs, I added props and passed in parameters to turn off autocapitalize and autocomplete
- 